### PR TITLE
feat(support): add prompt.html with Seed Planning design

### DIFF
--- a/support/prompt.html
+++ b/support/prompt.html
@@ -1,0 +1,503 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>プロンプト上達のコツ｜Seed Planning 自己学習教材</title>
+<style>
+:root{
+  --seed-blue: #0B62A3;
+  --seed-accent: #EAF3FA;
+  --seed-text: #1D2A36;
+  --bg: #ffffff;
+  --muted: #6b7a89;
+  --code-bg: #f6f8fa;
+  --border: #e5eef6;
+}
+* { box-sizing: border-box; }
+html, body { height: 100%; margin: 0; }
+body {
+  font-family: "Noto Sans JP","Hiragino Kaku Gothic ProN","Meiryo","Yu Gothic",system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  color: var(--seed-text);
+  background: var(--bg);
+  line-height: 1.7;
+}
+header.topbar {
+  position: fixed; inset: 0 0 auto 0; height: 56px;
+  display: flex; align-items: center; gap: 16px;
+  padding: 0 20px;
+  background: linear-gradient(90deg,var(--seed-blue), #0a4d80);
+  color: #fff; z-index: 10;
+  box-shadow: 0 2px 10px rgba(0,0,0,.08);
+}
+header.topbar .brand {
+  font-weight: 700; letter-spacing: .4px; font-size: 16px;
+}
+header.topbar .title { opacity:.95; font-size:14px; }
+main {
+  margin-top: 56px;
+  padding: 40px clamp(18px,4vw,56px);
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+}
+.cover {
+  text-align: center;
+  padding: 60px 0;
+  background: linear-gradient(135deg, var(--seed-accent) 0%, #ffffff 100%);
+  border-radius: 12px;
+  margin-bottom: 40px;
+}
+h1, h2, h3 { line-height: 1.35; margin: .8em 0 .4em 0; }
+h1 { font-size: clamp(28px, 4vw, 48px); color: var(--seed-blue); font-weight: 700; }
+h2 { font-size: clamp(22px, 3vw, 32px); color: var(--seed-blue); font-weight: 600; }
+h3 { font-size: clamp(18px, 2.5vw, 24px); color: var(--seed-blue); font-weight: 500; }
+h4 { font-size: clamp(16px, 2vw, 20px); color: var(--seed-text); font-weight: 600; margin: 1em 0 .3em 0; }
+.subtitle {
+  font-size: clamp(16px, 2vw, 20px);
+  color: var(--muted);
+  margin-bottom: 20px;
+}
+.lead {
+  font-size: clamp(16px, 2vw, 18px);
+  line-height: 1.6;
+  margin-bottom: 30px;
+}
+.callout {
+  border-left: 4px solid var(--seed-blue); 
+  background: var(--seed-accent);
+  padding: 20px 24px; 
+  border-radius: 6px; 
+  margin: 24px 0;
+  font-size: 15px;
+}
+.callout strong {
+  color: var(--seed-blue);
+}
+.section {
+  margin: 50px 0;
+  padding: 30px 0;
+  border-bottom: 1px solid var(--border);
+}
+.section:last-child {
+  border-bottom: none;
+}
+.part-header {
+  background: var(--seed-blue);
+  color: white;
+  padding: 30px;
+  text-align: center;
+  border-radius: 12px;
+  margin: 50px 0 30px 0;
+}
+.part-header h2 {
+  color: white;
+  margin: 0;
+  font-size: clamp(24px, 3vw, 36px);
+}
+.part-header .subtitle {
+  color: rgba(255,255,255,0.9);
+  margin: 10px 0 0 0;
+}
+ul, ol { 
+  padding-left: 1.2em; 
+  margin: 16px 0;
+}
+li { 
+  margin: 8px 0; 
+  line-height: 1.6;
+}
+.principles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+  margin: 30px 0;
+}
+.principle-card {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 20px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0,0,0,.05);
+}
+.principle-card h4 {
+  color: var(--seed-blue);
+  margin-top: 0;
+  font-size: 18px;
+}
+.comparison {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin: 30px 0;
+}
+.bad, .good {
+  padding: 20px;
+  border-radius: 8px;
+  border: 2px solid;
+}
+.bad {
+  border-color: #f56565;
+  background: #fed7d7;
+  color: #742a2a;
+}
+.good {
+  border-color: #48bb78;
+  background: #c6f6d5;
+  color: #22543d;
+}
+.prompt-example {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 20px;
+  margin: 20px 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+.example-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 25px;
+  margin: 30px 0;
+}
+.example-card {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  background: #fff;
+  box-shadow: 0 2px 10px rgba(0,0,0,.06);
+}
+.example-card h4 {
+  margin-top: 0;
+  color: var(--seed-blue);
+  border-bottom: 2px solid var(--seed-accent);
+  padding-bottom: 8px;
+}
+.checklist {
+  background: #f7fafc;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 25px;
+  margin: 30px 0;
+}
+.checklist h4 {
+  color: var(--seed-blue);
+  margin-top: 0;
+}
+.checklist ul {
+  list-style: none;
+  padding-left: 0;
+}
+.checklist li {
+  position: relative;
+  padding-left: 25px;
+  margin: 12px 0;
+}
+.checklist li::before {
+  content: "✓";
+  position: absolute;
+  left: 0;
+  color: var(--seed-blue);
+  font-weight: bold;
+}
+.footer {
+  margin-top: 60px;
+  padding: 30px 0;
+  text-align: center;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 14px;
+}
+@media (max-width: 768px) {
+  .comparison {
+    grid-template-columns: 1fr;
+  }
+  .principles {
+    grid-template-columns: 1fr;
+  }
+}
+</style>
+</head>
+<body>
+<header class="topbar">
+  <div class="brand">Seed Planning</div>
+  <div class="title">プロンプト上達のコツ（自己学習教材）</div>
+</header>
+
+<main>
+  <!-- Cover Section -->
+  <div class="cover">
+    <h1>プロンプト上達のコツ</h1>
+    <div class="subtitle">— シード・プランニング社員向け・自己学習教材（3部構成）—</div>
+    
+    <div class="callout" style="text-align: left; max-width: 800px; margin: 40px auto;">
+      <h3 style="margin-top: 0;">ねらい</h3>
+      <p>本教材は、社員が「自分の業務に当てはめて」すぐ使えるプロンプト術を、基本から応用まで やさしく解説します。調査会社である私たちの実務（公募案件、企画本、提案書、翻訳・要約、議事録・レポート作成など）に直結する具体例を収録しました。</p>
+      
+      <h4>読み方の目安</h4>
+      <ul>
+        <li><strong>パート1（基本）</strong>：まずはここから。つまずきやすいポイントとコツを15分で把握。</li>
+        <li><strong>パート2（業務直結例）</strong>：自分の仕事のページを見つけたら、そのまま試すだけ。</li>
+        <li><strong>パート3（高度版）</strong>：AIになりきらせる／10倍発想など、ピークパフォーマンスを引き出す。</li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- PART 1 -->
+  <div class="part-header">
+    <h2>PART 1｜まずはここから：プロンプトの基本</h2>
+  </div>
+
+  <div class="section">
+    <h3>1-1 なぜプロンプトが大事？</h3>
+    <p class="lead">良いアウトプットは「良いプロンプト」から。社内B3チームの実務でも、翻訳・要約・下書き生成・書き起こしチェック等で大幅な時短と品質の均一化を実現しました（例：スクリーナー整合性の自動チェック、報告書の叩き台生成、面談当日の追加質問の即時翻訳など）。</p>
+    <div class="callout">
+      <strong>※参考：</strong>業務フローのAI代替状況レポート_v4のプロンプト例（翻訳、メール添削、厚労省リサーチ、書き起こしチェック、レポート草稿）
+    </div>
+  </div>
+
+  <div class="section">
+    <h3>1-2 基本の4原則</h3>
+    <div class="principles">
+      <div class="principle-card">
+        <h4>目的</h4>
+        <p>誰向けに、何のための出力？</p>
+      </div>
+      <div class="principle-card">
+        <h4>背景</h4>
+        <p>前提・制約・既知情報（対象、期間、用途、トーン、評価観点）</p>
+      </div>
+      <div class="principle-card">
+        <h4>形式</h4>
+        <p>箇条書き／表／テンプレなど、望むアウトプットの形を明示</p>
+      </div>
+      <div class="principle-card">
+        <h4>段階</h4>
+        <p>難しい依頼は分割。概要→詳細→仕上げの順でキャッチボール</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h3>1-3 よくあるつまずきと改善</h3>
+    <ul>
+      <li><strong>曖昧な指示</strong> → 目的と読者像を先に明記。</li>
+      <li><strong>前提不足</strong> → 背景・制約・評価観点を添える。</li>
+      <li><strong>一度に詰め込み</strong> → ステップに分けて段階的に依頼。</li>
+      <li><strong>検証不足</strong> → 出典付きで依頼し、重要箇所は人がレビュー。</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h3>1-4 ミニ演習（悪い→良い）</h3>
+    <div class="comparison">
+      <div class="bad">
+        <h4>悪い例</h4>
+        <p>「公募案件の企画書を作って」</p>
+      </div>
+      <div class="good">
+        <h4>良い例</h4>
+        <p>「○○省△△事業の仕様書PDF（別添）に基づき、当社の強み（定性調査・医療・BtoB）を活かした提案の骨子（章立て＋各章のねらい・スケジュール・体制・概算費用レンジ）を評価基準に対応させて箇条書きで。」</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- PART 2 -->
+  <div class="part-header">
+    <h2>PART 2｜業務でそのまま使える：実務直結プロンプト集</h2>
+  </div>
+
+  <div class="section">
+    <h3>2-1 メール：クライアントへの「丁寧なお断り」仕上げ</h3>
+    <p><strong>【状況】</strong>下書きはあるが、表現の角を取りつつ誠実さと代替案を示したい。</p>
+    
+    <h4>プロンプト例</h4>
+    <div class="prompt-example">あなたは日本のビジネスマナーに詳しい営業マネージャーです。
+次の「お断りメール」の下書きを、
+1) 誠実で丁寧／2) 背景への共感／3) 代替案（時期／他社紹介／別プラン）／4) 角が立たない言い回し
+を踏まえて推敲してください。
+
+【相手】大手メーカーのX様（長年のご関係）
+【目的】今回のスケジュールでは対応が難しい旨を、信頼を損なわずにお伝え
+【トーン】フォーマル、簡潔、ポジティブクローズ
+【出力形式】件名案3つ／本文（日本語）／要点箇条書き（社内共有用）
+
+--- 下書き ---
+（ここに自分の下書きを貼る）</div>
+    
+    <div class="callout">
+      <strong>ヒント：</strong>社内レポートでは「メール添削」プロンプトにトーン指定を加える工夫が紹介されています。
+    </div>
+  </div>
+
+  <div class="section">
+    <h3>2-2 公募案件：まったく知らない領域に挑むとき</h3>
+    <p><strong>【状況】</strong>仕様書を読み解き、要件分解・不足情報の洗い出し・初期提案の骨子作りまでを最短距離で。</p>
+    
+    <h4>プロンプト例（仕様書アップロード前提）</h4>
+    <div class="prompt-example">あなたは公共調達の提案審査官の視点も持つ、調査設計の専門家です。
+添付の「公募仕様書PDF」を踏まえて、以下を順に出力してください。
+
+1) 事業の目的・背景・評価観点の要約（200〜300字）
+2) 要件分解（必須要件／望ましい要件／評価配点に直結する要素）
+3) 不足情報と、発注側に確認したい質問リスト（箇条書き）
+4) 提案骨子（章立て、各章のねらい、想定スケジュール、体制、概算費用レンジ）
+5) 当社の優位性になり得るポイント（3〜5点）とリスク（対応策つき）
+
+【出力形式】各項目見出し＋箇条書き／最後に「次の深掘り候補（3点）」</div>
+    
+    <h4>（追加依頼：ドメイン理解）</h4>
+    <div class="prompt-example">この領域の入門として、主要プレイヤー／関連制度・政策／用語集（20語）を「要点だけ」早わかりで。
+さらに、当社の既存実績と接続できる観点（ユースケース）も3つ挙げて。</div>
+    
+    <div class="callout">
+      <strong>ヒント：</strong>厚労省・ガイドライン等を扱う場合は「出典付き」を指示。重要情報は人が最終確認。
+    </div>
+  </div>
+
+  <div class="section">
+    <h3>2-3 企画本：AIに任せると進むポイント</h3>
+    <ul>
+      <li><strong>読者ペルソナと言語化</strong>：誰のどんな課題を解く本かを先に固定。</li>
+      <li><strong>章立てと各章の「ねらい」整理</strong>：章ごとに読者価値と学びの遷移を設計。</li>
+      <li><strong>事例・コラム候補のブレスト</strong>：視点の抜け漏れを補う。</li>
+      <li><strong>図表アイデア</strong>：1枚で伝わる構造図・比較表・プロセス図の叩き台。</li>
+      <li><strong>草稿のリライト</strong>：語り口統一、冗長削減、見出しのキャッチ強化。</li>
+    </ul>
+    
+    <h4>プロンプト例</h4>
+    <div class="prompt-example">あなたはビジネス書の編集者です。
+以下の企画メモをもとに、(1)読者ペルソナ定義、(2)章立て（各章のねらい・要点3つずつ）、
+(3)図表アイデア（3点）、(4)コラム候補（3本）を提案してください。
+最後に、全体のタイトル案を5つ。
+
+【企画メモ】（ここに企画の狙い・既存章案・想定読者・差別化ポイントを貼る）
+【トーン】読みやすく・具体的・実務に役立つ
+【制約】出典が必要な事実は「要出典」と明記。</div>
+  </div>
+
+  <div class="section">
+    <h3>2-4 翻訳・要約・転用（医療・BtoB前提）</h3>
+    <div class="example-grid">
+      <div class="example-card">
+        <h4>翻訳</h4>
+        <div class="prompt-example">この英文を、日本の医療現場で自然な表現に整えて日本語訳してください。
+対象は医師。専門用語は一般的な用法を優先し、不明な用語は注釈を付与。
+【出力】日本語訳＋用語注釈（箇条書き）</div>
+      </div>
+      <div class="example-card">
+        <h4>要約</h4>
+        <div class="prompt-example">以下の長文を、(1)要点5つ、(2)重要数値、(3)示唆の順で400字程度に要約してください。
+判断に関わる箇所は原文の語を維持。</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h3>2-5 議事録・書き起こし・レポート</h3>
+    <div class="example-grid">
+      <div class="example-card">
+        <h4>書き起こしチェック</h4>
+        <div class="prompt-example">この書き起こし（日本語）に誤認識・話者混同・医学用語の誤記がないかチェックし、
+修正案を提示してください。</div>
+      </div>
+      <div class="example-card">
+        <h4>レポート草稿</h4>
+        <div class="prompt-example">添付の書き起こしをもとに、報告書のサマリー叩き台を作成。
+調査目的を意識した要約→示唆→次アクションの順で、見出し＋箇条書きで。</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h3>2-6 スクリーナーの国内適合性チェック</h3>
+    <h4>プロンプト例</h4>
+    <div class="prompt-example">あなたは日本の医療制度・薬機法・適応を理解する調査PMです。
+添付のスクリーナー草案について、国内実情との整合性を点検してください。
+
+1) 条件の過不足（国内承認・適応・用語の整合）
+2) リクルート上の現実性リスク
+3) 修正提案（表現例つき）</div>
+  </div>
+
+  <!-- PART 3 -->
+  <div class="part-header">
+    <h2>PART 3｜ピークパフォーマンスを引き出す：高度プロンプト</h2>
+  </div>
+
+  <div class="section">
+    <h3>3-1 ロール付与（AIになりきらせる）</h3>
+    <ul>
+      <li><strong>エネルギー政策アナリスト</strong>／規制動向の要点と事業影響の整理</li>
+      <li><strong>ヘルスケア市場アナリスト</strong>／疾患領域の市場構造・患者導線の俯瞰</li>
+      <li><strong>公共調達の審査官</strong>／評価基準で提案骨子をレビュー</li>
+      <li><strong>編集長</strong>／章立ての流れ・読者価値・見出しの強度を評価</li>
+      <li><strong>法務チェック（一般的助言）</strong>／表現上のリスク示唆（※最終判断は人）</li>
+    </ul>
+    
+    <h4>プロンプト例</h4>
+    <div class="prompt-example">あなたは公共調達の審査官です。
+次の提案骨子を、評価基準（配点）に照らして加点・減点の観点を洗い出し、
+改善指示をください。最後に、加点を最大化する改稿版の見出し案を3つ。
+
+--- 提案骨子 ---
+（ここに骨子を貼る）</div>
+  </div>
+
+  <div class="section">
+    <h3>3-2 「10倍」発想を出すチャレンジ</h3>
+    <h4>プロンプト例</h4>
+    <div class="prompt-example">あなたは戦略コンサルタントです。
+次のゴールを「10倍」良くするためのアイデアを、制約条件を踏まえて発想してください。
+
+【ゴール】○○（例：調査参加率の向上）
+【制約】予算上限◯◯万円／実施まで◯週間／品質基準◯◯
+【出力】(1)打ち手10個（低コスト順）(2)インパクト×実行難易度のマトリクス評価 
+(3)最初の72時間で着手できる3ステップ</div>
+  </div>
+
+  <div class="section">
+    <h3>3-3 出典・検証・ファイル活用のコツ</h3>
+    <ul>
+      <li>重要情報は<strong>「出典付き」</strong>で依頼（例：厚労省・ガイドライン・統計のURL）。</li>
+      <li>AIの回答は必ず<strong>社内レビュー</strong>で検証（事実関係・表現の適切性）。</li>
+      <li>ファイルは仕様書・スクリーナー・議事録など<strong>「文脈の源泉」</strong>を積極投入。</li>
+      <li>良かった出力は<strong>プロンプトとセット</strong>で社内ナレッジ化（テンプレとして再利用）。</li>
+    </ul>
+  </div>
+
+  <!-- 付録 -->
+  <div class="part-header">
+    <h2>付録｜タイプ別の学び方＆社内サポート</h2>
+  </div>
+
+  <div class="section">
+    <ul>
+      <li><strong>先進層</strong>：毎日使って満足 → 活用例の共有役に。社内テンプレ整備を主導。</li>
+      <li><strong>潜在層</strong>：未利用だが「翻訳・調査」に興味 → プロンプト例から短時間で成功体験を。</li>
+      <li><strong>慎重層</strong>：セキュリティ・ルール不安 → 利用範囲・手順・FAQを整備し安心感を提供。</li>
+      <li><strong>冷淡層</strong>：ほとんど使わず不満 → 過度にリソースをかけず、成功事例の定期共有に留める。</li>
+    </ul>
+
+    <div class="checklist">
+      <h4>チェックリスト（はじめの一歩）</h4>
+      <ul>
+        <li>目的・読者・用途を書いたか？</li>
+        <li>背景・制約（期日・分量・評価観点）を伝えたか？</li>
+        <li>出力形式（箇条書き／表／テンプレ）を指定したか？</li>
+        <li>段階的に依頼し、検証→改善のループを回したか？</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="footer">
+    © Seed Planning — 社外秘／社内学習用途に限る
+  </div>
+</main>
+
+</body>
+</html>


### PR DESCRIPTION
- Create comprehensive prompt mastery guide based on PDF content
- Use consistent design with Seed Planning brand colors and typography
- Include all 3 parts: basics, practical examples, and advanced techniques
- Add interactive elements with proper styling for better UX
- Cover business scenarios: emails, RFPs, books, translation, reports
- Maintain Japanese localization and business context