### PR TITLE
Remove backup/export section from Yoshi page

### DIFF
--- a/yoshi/index.html
+++ b/yoshi/index.html
@@ -125,23 +125,6 @@
           <p class="empty-text">まだメモはありません。最初のひとこと、残してみる？</p>
         </div>
       </section>
-
-      <!-- エクスポート＆削除 -->
-      <section class="card export-card">
-        <h2>バックアップ / エクスポート</h2>
-        <p class="hint-text">
-          これまでの記録を、タブ区切りテキスト（.txt）としてダウンロードできます。<br />
-          Excelやスプレッドシートで開けば、あとからゆっくり振り返れます。
-        </p>
-        <div class="button-row">
-          <button id="exportButton" class="outline-button" type="button">
-            テキストで保存する
-          </button>
-          <button id="clearButton" class="danger-button outline-button small" type="button">
-            すべて削除…
-          </button>
-        </div>
-      </section>
     </main>
 
     <footer class="app-footer">


### PR DESCRIPTION
## Summary
- remove the backup/export section from the Yoshi memo page to hide export and delete controls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f8ea3b58c83319840f6d1a515549c)