### PR TITLE
Adjust daytime event cloud cadence

### DIFF
--- a/yoshi/app.js
+++ b/yoshi/app.js
@@ -592,20 +592,33 @@
     });
   }
 
-  // ---- ☁️⚡ 入道雲イベント（30秒〜1分に1度） ----
+  // ---- ☁️⚡ 入道雲イベント（1分に1度） ----
   function startEventCloud() {
     const layer = document.getElementById("cloudLayer");
     if (!layer) return;
 
     let eventCloudElement = null;
     let isEventRunning = false;
+    const eventDurationMs = 60000; // ゆっくり60秒かけて横切る
+
+    function applyEventCloudStyles(element) {
+      // 出現位置やスケールを少しずつ変えて、自然な動きに
+      const startScale = 0.7 + Math.random() * 0.8; // 0.7〜1.5
+      const endScale = Math.min(1.5, startScale + 0.2 + Math.random() * 0.4);
+      const topPosition = 12 + Math.random() * 28; // 12〜40vh
+
+      element.style.setProperty("--event-cloud-start-scale", startScale.toFixed(2));
+      element.style.setProperty("--event-cloud-end-scale", endScale.toFixed(2));
+      element.style.top = `${topPosition}vh`;
+      element.style.setProperty("--event-cloud-duration", `${eventDurationMs / 1000}s`);
+    }
 
     function spawnEventCloud() {
       // 昼または朝のテーマのときのみ表示
-      const isDayOrMorning = 
+      const isDayOrMorning =
         document.body.classList.contains("theme-day") ||
         document.body.classList.contains("theme-morning");
-      
+
       if (!isDayOrMorning || isEventRunning) return;
 
       // 既存の入道雲があれば削除
@@ -616,6 +629,7 @@
       // 新しい入道雲を作成
       eventCloudElement = document.createElement("div");
       eventCloudElement.className = "event-cloud";
+      applyEventCloudStyles(eventCloudElement);
       layer.appendChild(eventCloudElement);
 
       // アニメーション開始
@@ -631,23 +645,23 @@
           eventCloudElement = null;
         }
         isEventRunning = false;
-      }, 46000); // 45秒のアニメーション + 1秒の余裕
+      }, eventDurationMs + 1000); // 60秒のアニメーション + 1秒の余裕
     }
 
     function scheduleNextEvent() {
-      // 30秒〜60秒のランダムな間隔
-      const nextDelay = 30000 + Math.random() * 30000;
+      // 毎分1回のペースで発生
+      const nextDelay = eventDurationMs;
       setTimeout(() => {
         spawnEventCloud();
         scheduleNextEvent();
       }, nextDelay);
     }
 
-    // 最初のイベントは10秒後に開始
+    // 最初のイベントは5秒後に開始
     setTimeout(() => {
       spawnEventCloud();
       scheduleNextEvent();
-    }, 10000);
+    }, 5000);
   }
 
   // ---- 🌆 夕方の雲イベント（画面上部と中央） ----

--- a/yoshi/styles.css
+++ b/yoshi/styles.css
@@ -963,6 +963,9 @@ body.theme-night .cloud-layer {
   pointer-events: none;
   opacity: 0;
   filter: blur(0.5px);
+  --event-cloud-start-scale: 0.7;
+  --event-cloud-end-scale: 1.2;
+  --event-cloud-duration: 60s;
   /* 画面の1/3を占める大きさ（高さ基準） */
   width: auto;
   height: 33vh;
@@ -978,13 +981,13 @@ body.theme-night .cloud-layer {
   0% {
     left: -40vw;
     opacity: 0;
-    transform: scale(0.7);
+    transform: scale(var(--event-cloud-start-scale));
   }
   5% {
     opacity: 0.9;
   }
   50% {
-    transform: scale(1.1);
+    transform: scale(calc((var(--event-cloud-start-scale) + var(--event-cloud-end-scale)) / 2));
   }
   95% {
     opacity: 0.9;
@@ -992,13 +995,13 @@ body.theme-night .cloud-layer {
   100% {
     left: 110vw;
     opacity: 0;
-    transform: scale(1.2);
+    transform: scale(var(--event-cloud-end-scale));
   }
 }
 
 /* アニメーションクラスが追加されたときに実行 */
 .event-cloud.active {
-  animation: eventCloudPass 45s ease-in-out forwards;
+  animation: eventCloudPass var(--event-cloud-duration) ease-in-out forwards;
 }
 
 /* =========================


### PR DESCRIPTION
## Summary
- adjust daytime event cloud scheduling to appear once per minute after a brief initial delay
- randomize event cloud position and scale for natural movement and sync animation duration with styling variables

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f935a5b888331a481d2ce3b4137ff)