### PR TITLE
Add weather forecast dashboard page

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,40 @@
             font-weight: 300;
         }
 
+        .header-actions {
+            margin-top: 1.2rem;
+            display: flex;
+            justify-content: center;
+            gap: 0.8rem;
+            flex-wrap: wrap;
+        }
+
+        .header-button {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.75rem 1.1rem;
+            background: white;
+            color: var(--primary-color);
+            border-radius: 12px;
+            font-weight: 700;
+            text-decoration: none;
+            box-shadow: var(--card-shadow);
+            transition: var(--transition);
+        }
+
+        .header-button.secondary {
+            background: rgba(255, 255, 255, 0.15);
+            color: white;
+            border: 1px solid rgba(255, 255, 255, 0.4);
+            box-shadow: none;
+        }
+
+        .header-button:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--hover-shadow);
+        }
+
         /* Container */
         .container {
             max-width: 1400px;
@@ -737,6 +771,12 @@
             <div class="header-content">
                 <h1>シード・プランニング | AI活用 FAQ</h1>
                 <p>社員向け 生成AI導入・活用ガイド</p>
+                <div class="header-actions">
+                    <a class="header-button" href="weather.html">
+                        <i class="fas fa-cloud-sun"></i>
+                        天気予報を見る
+                    </a>
+                </div>
             </div>
         </div>
     </header>

--- a/weather.html
+++ b/weather.html
@@ -1,0 +1,393 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>シード・プランニング | 天気予報ダッシュボード</title>
+    <link rel="icon" type="image/png" sizes="192x192" href="seedplanning_logo_192.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="seedplanning_logo_192.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="seedplanning_logo_192.png">
+    <link rel="shortcut icon" href="seedplanning_logo_192.png">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet">
+    <style>
+        :root {
+            --primary-color: #8B4513;
+            --secondary-color: #A0522D;
+            --accent-color: #D2691E;
+            --bg-color: #f7f4ef;
+            --text-color: #2f2f2f;
+            --border-color: rgba(0,0,0,0.05);
+            --card-shadow: 0 12px 30px rgba(0,0,0,0.08);
+            --glow: 0 10px 30px rgba(210, 169, 102, 0.35);
+        }
+
+        * { box-sizing: border-box; }
+
+        body {
+            margin: 0;
+            font-family: 'Noto Sans JP', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: linear-gradient(145deg, #fdfbf8 0%, #f3eee7 100%);
+            color: var(--text-color);
+            min-height: 100vh;
+        }
+
+        .hero {
+            position: relative;
+            padding: 3.5rem 1.5rem 2.5rem;
+            color: white;
+            text-align: center;
+            overflow: hidden;
+            background: linear-gradient(135deg, rgba(139, 69, 19, 0.92), rgba(210, 180, 140, 0.9)),
+                        url('network-background.jpg') center/cover;
+            box-shadow: var(--card-shadow);
+        }
+
+        .hero::after {
+            content: '';
+            position: absolute;
+            top: -40%;
+            right: -20%;
+            width: 70%;
+            height: 180%;
+            background: radial-gradient(circle at center, rgba(255,255,255,0.2), transparent 55%);
+            filter: blur(12px);
+            transform: rotate(-12deg);
+        }
+
+        .hero .logo {
+            position: absolute;
+            top: 1.2rem;
+            left: 1.6rem;
+            height: 64px;
+            width: auto;
+            background: rgba(255,255,255,0.95);
+            padding: 10px;
+            border-radius: 12px;
+            box-shadow: 0 4px 15px rgba(0,0,0,0.12);
+            z-index: 2;
+        }
+
+        .hero-content {
+            position: relative;
+            z-index: 1;
+            max-width: 880px;
+            margin: 0 auto;
+        }
+
+        .hero h1 {
+            font-size: clamp(2.2rem, 3vw, 3.1rem);
+            margin: 0 0 0.6rem;
+            letter-spacing: -0.02em;
+        }
+
+        .hero p {
+            margin: 0 0 1.2rem;
+            font-size: 1.1rem;
+            opacity: 0.95;
+        }
+
+        .hero-actions {
+            display: flex;
+            justify-content: center;
+            gap: 0.8rem;
+            flex-wrap: wrap;
+            margin-top: 1.1rem;
+        }
+
+        .hero-actions a {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.6rem;
+            padding: 0.9rem 1.3rem;
+            background: white;
+            color: var(--primary-color);
+            font-weight: 700;
+            text-decoration: none;
+            border-radius: 12px;
+            box-shadow: var(--glow);
+            transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+        }
+
+        .hero-actions a.secondary {
+            background: rgba(255,255,255,0.15);
+            color: white;
+            border: 1px solid rgba(255,255,255,0.4);
+            box-shadow: none;
+        }
+
+        .hero-actions a:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 15px 35px rgba(0,0,0,0.12);
+        }
+
+        main {
+            max-width: 1200px;
+            margin: -2.5rem auto 2rem;
+            padding: 0 1.5rem 2rem;
+            position: relative;
+            z-index: 3;
+        }
+
+        .card {
+            background: rgba(255,255,255,0.95);
+            border-radius: 16px;
+            padding: 1.4rem 1.6rem;
+            border: 1px solid rgba(255,255,255,0.7);
+            box-shadow: var(--card-shadow);
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+        }
+
+        .controls {
+            display: grid;
+            grid-template-columns: 1.2fr 0.8fr;
+            gap: 1rem;
+            margin-bottom: 1.2rem;
+        }
+
+        @media (max-width: 960px) {
+            .controls {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .search-box form {
+            display: flex;
+            gap: 0.8rem;
+            flex-wrap: wrap;
+        }
+
+        .search-box input {
+            flex: 1;
+            min-width: 220px;
+            padding: 0.95rem 1rem;
+            border-radius: 12px;
+            border: 1px solid #e6d8cf;
+            font-size: 1rem;
+            background: rgba(255,255,255,0.9);
+        }
+
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.85rem 1rem;
+            border-radius: 12px;
+            border: none;
+            cursor: pointer;
+            font-weight: 700;
+            background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+            color: white;
+            box-shadow: var(--glow);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .btn.secondary {
+            background: transparent;
+            color: var(--primary-color);
+            border: 1px solid #e4cbb9;
+            box-shadow: none;
+        }
+
+        .btn:hover { transform: translateY(-1px); box-shadow: 0 12px 24px rgba(0,0,0,0.12); }
+
+        .status {
+            margin-top: 0.75rem;
+            font-size: 0.95rem;
+            color: var(--primary-color);
+        }
+
+        .status.error { color: #b94a48; }
+        .status.success { color: #1b7f36; }
+
+        .results {
+            display: grid;
+            gap: 0.5rem;
+            margin-top: 0.8rem;
+        }
+
+        .result-item {
+            padding: 0.75rem 0.9rem;
+            border-radius: 10px;
+            border: 1px solid #e9ded5;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.6rem;
+            background: #fff8f2;
+        }
+
+        .result-title { font-weight: 700; }
+        .result-meta { color: #6b5c55; font-size: 0.9rem; }
+
+        .weather-layout {
+            display: grid;
+            grid-template-columns: 1.1fr 0.9fr;
+            gap: 1rem;
+        }
+
+        @media (max-width: 960px) { .weather-layout { grid-template-columns: 1fr; } }
+
+        .current-weather {
+            display: grid;
+            gap: 0.8rem;
+            grid-template-columns: 1fr;
+        }
+
+        .current-top {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.6rem;
+        }
+
+        .temp-main {
+            font-size: clamp(2.8rem, 5vw, 3.6rem);
+            font-weight: 800;
+            letter-spacing: -0.03em;
+        }
+
+        .condition {
+            display: flex;
+            align-items: center;
+            gap: 0.6rem;
+            font-size: 1.05rem;
+            color: #5b4b44;
+        }
+
+        .sub-info { color: #6e635e; }
+
+        .badges {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+
+        .badge {
+            padding: 0.4rem 0.7rem;
+            border-radius: 999px;
+            background: #f1e7de;
+            color: var(--primary-color);
+            font-weight: 700;
+            font-size: 0.9rem;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+
+        .forecast {
+            margin-top: 1rem;
+        }
+
+        .forecast-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 0.9rem;
+        }
+
+        .forecast-card {
+            padding: 1rem;
+            border-radius: 14px;
+            background: #fffaf5;
+            border: 1px solid #e9ded5;
+            box-shadow: var(--card-shadow);
+        }
+
+        .forecast-card h4 { margin: 0 0 0.4rem; }
+        .forecast-meta { color: #6e635e; font-size: 0.9rem; }
+        .forecast-temp { font-size: 1.4rem; font-weight: 800; }
+
+        .hourly {
+            margin-top: 1rem;
+        }
+
+        .hourly-list {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 0.6rem;
+        }
+
+        .hourly-item {
+            padding: 0.8rem 0.9rem;
+            border-radius: 12px;
+            border: 1px solid #e9ded5;
+            background: white;
+        }
+
+        footer {
+            text-align: center;
+            padding: 1.2rem;
+            color: #7a6b63;
+            font-size: 0.95rem;
+        }
+    </style>
+</head>
+<body>
+    <header class="hero">
+        <img src="seedplanning_logo_192.png" alt="Seed Planning" class="logo">
+        <div class="hero-content">
+            <h1><i class="fa-solid fa-cloud-sun"></i> 天気予報ダッシュボード</h1>
+            <p>主要都市や現在地の天気を、最新のオープンデータからシンプルに表示します。</p>
+            <div class="hero-actions">
+                <a href="index.html"><i class="fa-solid fa-arrow-left"></i> FAQトップへ戻る</a>
+                <a href="#forecast" class="secondary"><i class="fa-solid fa-location-dot"></i> 予報へ移動</a>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="controls">
+            <div class="card search-box">
+                <h2><i class="fa-solid fa-magnifying-glass-location"></i> 地域を検索</h2>
+                <form id="locationForm">
+                    <input id="locationInput" type="text" placeholder="例: 東京, Osaka, Yokohama" aria-label="地域名を入力">
+                    <button class="btn" type="submit"><i class="fa-solid fa-search"></i> 検索</button>
+                    <button class="btn secondary" type="button" id="geoButton"><i class="fa-solid fa-crosshairs"></i> 現在地から取得</button>
+                </form>
+                <div id="status" class="status">「東京」の予報を表示中</div>
+                <div id="results" class="results" aria-live="polite"></div>
+            </div>
+            <div class="card">
+                <h2><i class="fa-solid fa-circle-info"></i> 使い方</h2>
+                <ul>
+                    <li>都市名や空港名を入力すると、候補を取得して切り替えられます。</li>
+                    <li>「現在地から取得」で端末の位置情報を利用して予報を表示します。</li>
+                    <li>気象データは Open-Meteo（オープンデータ）を利用しています。</li>
+                    <li>ブラウザは直近に閲覧した地域を記憶します。</li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="weather-layout" id="forecast">
+            <div class="card current-weather">
+                <div class="current-top">
+                    <div>
+                        <div class="condition" id="locationName"><i class="fa-solid fa-location-dot"></i> 東京</div>
+                        <div class="temp-main" id="currentTemp">--°C</div>
+                        <div class="condition" id="currentSummary">最新の状況を取得しています...</div>
+                    </div>
+                    <div class="badges" id="currentBadges"></div>
+                </div>
+                <div class="sub-info" id="updatedAt">更新: --</div>
+            </div>
+
+            <div class="card hourly">
+                <h3><i class="fa-solid fa-droplet"></i> 直近の降水確率</h3>
+                <div id="hourlyList" class="hourly-list"></div>
+            </div>
+        </section>
+
+        <section class="forecast card">
+            <h3><i class="fa-solid fa-calendar-week"></i> 5日間の予報</h3>
+            <div id="forecastGrid" class="forecast-grid"></div>
+        </section>
+    </main>
+
+    <footer>
+        気象データ提供: <a href="https://open-meteo.com/" target="_blank" rel="noopener">Open-Meteo</a> | Seed Planning Global
+    </footer>
+
+    <script src="weather.js"></script>
+</body>
+</html>

--- a/weather.js
+++ b/weather.js
@@ -1,0 +1,284 @@
+const defaultLocation = {
+    name: '東京',
+    latitude: 35.6762,
+    longitude: 139.6503,
+    country: '日本',
+    timezone: 'Asia/Tokyo'
+};
+
+const selectors = {
+    status: document.getElementById('status'),
+    locationForm: document.getElementById('locationForm'),
+    locationInput: document.getElementById('locationInput'),
+    geoButton: document.getElementById('geoButton'),
+    results: document.getElementById('results'),
+    locationName: document.getElementById('locationName'),
+    currentTemp: document.getElementById('currentTemp'),
+    currentSummary: document.getElementById('currentSummary'),
+    updatedAt: document.getElementById('updatedAt'),
+    currentBadges: document.getElementById('currentBadges'),
+    forecastGrid: document.getElementById('forecastGrid'),
+    hourlyList: document.getElementById('hourlyList'),
+};
+
+const STORAGE_KEY = 'sp-weather:last-location';
+
+function setStatus(message, type = 'info') {
+    if (!selectors.status) return;
+    selectors.status.textContent = message;
+    selectors.status.className = `status ${type}`;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    bindEvents();
+    const storedLocation = readStoredLocation();
+    fetchAndRenderWeather(storedLocation || defaultLocation);
+});
+
+function bindEvents() {
+    selectors.locationForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const query = selectors.locationInput.value.trim();
+        if (!query) {
+            setStatus('地域名を入力してください。', 'error');
+            return;
+        }
+        await searchLocation(query);
+    });
+
+    selectors.geoButton.addEventListener('click', () => {
+        if (!navigator.geolocation) {
+            setStatus('位置情報が利用できません。入力検索をご利用ください。', 'error');
+            return;
+        }
+
+        setStatus('現在地を取得しています...', 'info');
+        navigator.geolocation.getCurrentPosition(async (pos) => {
+            const { latitude, longitude } = pos.coords;
+            const location = {
+                name: '現在地',
+                latitude,
+                longitude,
+                country: '',
+                timezone: 'auto'
+            };
+            await fetchAndRenderWeather(location);
+        }, () => {
+            setStatus('現在地の取得に失敗しました。権限と通信状況をご確認ください。', 'error');
+        });
+    });
+}
+
+async function searchLocation(query) {
+    setStatus('候補を検索しています...', 'info');
+    selectors.results.innerHTML = '';
+
+    try {
+        const url = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(query)}&count=5&language=ja&format=json`;
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`Geocoding HTTP ${res.status}`);
+        const data = await res.json();
+
+        if (!data.results || data.results.length === 0) {
+            setStatus('候補が見つかりませんでした。別のキーワードをお試しください。', 'error');
+            return;
+        }
+
+        renderSearchResults(data.results);
+        setStatus('候補から表示したい地域を選択してください。', 'success');
+    } catch (error) {
+        console.error('Search error', error);
+        setStatus('検索中に問題が発生しました。通信状況をご確認ください。', 'error');
+    }
+}
+
+function renderSearchResults(results) {
+    selectors.results.innerHTML = '';
+    results.forEach((item) => {
+        const location = {
+            name: item.name,
+            latitude: item.latitude,
+            longitude: item.longitude,
+            country: item.country || '',
+            timezone: item.timezone || 'auto'
+        };
+
+        const div = document.createElement('div');
+        div.className = 'result-item';
+        div.innerHTML = `
+            <div>
+                <div class="result-title">${location.name}</div>
+                <div class="result-meta">${location.country} / ${item.admin1 || ''} / 緯度${location.latitude.toFixed(2)}, 経度${location.longitude.toFixed(2)}</div>
+            </div>
+            <button class="btn secondary" type="button"><i class="fa-solid fa-arrow-right"></i> この地域の予報</button>
+        `;
+
+        div.querySelector('button').addEventListener('click', async () => {
+            selectors.results.innerHTML = '';
+            await fetchAndRenderWeather(location);
+        });
+
+        selectors.results.appendChild(div);
+    });
+}
+
+async function fetchAndRenderWeather(location) {
+    try {
+        setStatus(`「${location.name}」の予報を取得しています...`, 'info');
+        const data = await fetchWeather(location);
+        renderCurrent(data, location);
+        renderDaily(data);
+        renderHourly(data);
+        storeLocation(location);
+        setStatus(`「${location.name}」の最新予報を表示中`, 'success');
+    } catch (error) {
+        console.error('Weather fetch error', error);
+        setStatus('予報の取得に失敗しました。時間をおいて再度お試しください。', 'error');
+    }
+}
+
+async function fetchWeather(location) {
+    const params = new URLSearchParams({
+        latitude: location.latitude,
+        longitude: location.longitude,
+        current_weather: 'true',
+        hourly: 'temperature_2m,precipitation_probability',
+        daily: 'weathercode,temperature_2m_max,temperature_2m_min,precipitation_probability_max',
+        forecast_days: '5',
+        timezone: location.timezone || 'auto'
+    });
+
+    const url = `https://api.open-meteo.com/v1/forecast?${params.toString()}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Forecast HTTP ${res.status}`);
+    return res.json();
+}
+
+function renderCurrent(data, location) {
+    const current = data.current_weather;
+    if (!current) return;
+
+    const info = getWeatherInfo(current.weathercode);
+    selectors.locationName.innerHTML = `<i class="fa-solid fa-location-dot"></i> ${location.name}${location.country ? `（${location.country}）` : ''}`;
+    selectors.currentTemp.textContent = `${Math.round(current.temperature)}°C`;
+    selectors.currentSummary.innerHTML = `<i class="${info.icon}"></i> ${info.label}`;
+    selectors.updatedAt.textContent = `更新: ${formatDateTime(current.time, data.timezone)}`;
+
+    selectors.currentBadges.innerHTML = '';
+    const wind = createBadge(`<i class="fa-solid fa-wind"></i> 風速 ${current.windspeed} km/h`);
+    const direction = createBadge(`<i class="fa-solid fa-compass"></i> 風向 ${current.winddirection}°`);
+    selectors.currentBadges.append(wind, direction);
+}
+
+function renderDaily(data) {
+    const { daily } = data;
+    if (!daily || !daily.time) return;
+
+    selectors.forecastGrid.innerHTML = '';
+    daily.time.forEach((date, index) => {
+        const code = daily.weathercode[index];
+        const info = getWeatherInfo(code);
+        const max = Math.round(daily.temperature_2m_max[index]);
+        const min = Math.round(daily.temperature_2m_min[index]);
+        const rain = daily.precipitation_probability_max?.[index];
+
+        const card = document.createElement('div');
+        card.className = 'forecast-card';
+        card.innerHTML = `
+            <h4>${formatDate(date)}</h4>
+            <div class="forecast-meta"><i class="${info.icon}"></i> ${info.label}</div>
+            <div class="forecast-temp">${max}°C / ${min}°C</div>
+            <div class="forecast-meta"><i class="fa-solid fa-umbrella"></i> 降水確率 ${rain ?? '--'}%</div>
+        `;
+        selectors.forecastGrid.appendChild(card);
+    });
+}
+
+function renderHourly(data) {
+    const { hourly } = data;
+    if (!hourly || !hourly.time) return;
+
+    const now = new Date();
+    const rows = hourly.time.map((t, i) => ({
+        time: t,
+        temperature: hourly.temperature_2m[i],
+        precipitation: hourly.precipitation_probability[i]
+    }))
+    .filter((row) => new Date(row.time) > now)
+    .slice(0, 8);
+
+    selectors.hourlyList.innerHTML = '';
+    rows.forEach((row) => {
+        const div = document.createElement('div');
+        div.className = 'hourly-item';
+        div.innerHTML = `
+            <div><strong>${formatTime(row.time)}</strong></div>
+            <div class="forecast-meta">気温 ${Math.round(row.temperature)}°C</div>
+            <div class="forecast-meta"><i class="fa-solid fa-droplet"></i> 降水確率 ${row.precipitation ?? '--'}%</div>
+        `;
+        selectors.hourlyList.appendChild(div);
+    });
+}
+
+function createBadge(html) {
+    const span = document.createElement('span');
+    span.className = 'badge';
+    span.innerHTML = html;
+    return span;
+}
+
+function getWeatherInfo(code) {
+    const mapping = [
+        { codes: [0], label: '快晴', icon: 'fa-solid fa-sun' },
+        { codes: [1, 2], label: '晴れ時々薄曇り', icon: 'fa-solid fa-cloud-sun' },
+        { codes: [3], label: '曇り', icon: 'fa-solid fa-cloud' },
+        { codes: [45, 48], label: '霧', icon: 'fa-solid fa-smog' },
+        { codes: [51, 53, 55], label: '霧雨', icon: 'fa-solid fa-cloud-rain' },
+        { codes: [61, 63, 65], label: '雨', icon: 'fa-solid fa-cloud-showers-heavy' },
+        { codes: [66, 67], label: '冷たい雨', icon: 'fa-solid fa-cloud-showers-water' },
+        { codes: [71, 73, 75, 77], label: '雪', icon: 'fa-solid fa-snowflake' },
+        { codes: [80, 81, 82], label: 'にわか雨', icon: 'fa-solid fa-cloud-sun-rain' },
+        { codes: [85, 86], label: 'にわか雪', icon: 'fa-solid fa-snowflake' },
+        { codes: [95, 96, 99], label: '雷雨', icon: 'fa-solid fa-cloud-bolt' },
+    ];
+
+    return mapping.find((m) => m.codes.includes(code)) || { label: '不明', icon: 'fa-solid fa-circle-question' };
+}
+
+function formatDate(dateString) {
+    const date = new Date(dateString);
+    const weekday = ['日', '月', '火', '水', '木', '金', '土'][date.getDay()];
+    return `${date.getMonth() + 1}/${date.getDate()} (${weekday})`;
+}
+
+function formatTime(dateString) {
+    const d = new Date(dateString);
+    return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function formatDateTime(dateString, timezone) {
+    const date = new Date(dateString);
+    return `${date.toLocaleString('ja-JP', { timeZone: timezone || 'Asia/Tokyo' })}`;
+}
+
+function pad(n) {
+    return n.toString().padStart(2, '0');
+}
+
+function storeLocation(location) {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(location));
+    } catch (error) {
+        console.warn('Failed to store location', error);
+    }
+}
+
+function readStoredLocation() {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        return raw ? JSON.parse(raw) : null;
+    } catch (error) {
+        console.warn('Failed to read stored location', error);
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add a standalone weather forecast dashboard powered by Open-Meteo with search, geolocation, and hourly/daily displays
- style the new page to match existing branding and navigation
- link the FAQ landing header to the new forecast experience

## Testing
- Visually inspected the weather dashboard locally


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69456791f8548331b1331e216cab6464)